### PR TITLE
Remove nginx-bot where possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,38 +173,39 @@ jobs:
               ./preflight check container quay.io/nginx/nginx-ingress-operator:${{ needs.build.outputs.version }} --pyxis-api-token ${{ secrets.PYXIS_API_TOKEN }} --certification-project-id ${{ secrets.CERTIFICATION_PROJECT_ID }} --platform $architecture --submit
           done
 
-      - name: Make
-        run: |
-          make bundle USE_IMAGE_DIGESTS=true
+      ## Disable PR creation until issues with NGINX_PAT are resolved
+      # - name: Make
+      #   run: |
+      #     make bundle USE_IMAGE_DIGESTS=true
 
-      - name: Checkout certified-operators repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          token: ${{ secrets.NGINX_PAT }}
-          repository: nginx-bot/certified-operators
-          path: certified-operators
+      # - name: Checkout certified-operators repo
+      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      #   with:
+      #     token: ${{ secrets.NGINX_PAT }}
+      #     repository: nginx-bot/certified-operators
+      #     path: certified-operators
 
-      - name: Update certified-operators repo
-        working-directory: certified-operators/operators/nginx-ingress-operator
-        run: |
-          mkdir v${{ needs.build.outputs.version }}
-          cp -R ../../../bundle/manifests v${{ needs.build.outputs.version }}/
-          cp -R ../../../bundle/metadata v${{ needs.build.outputs.version }}/
+      # - name: Update certified-operators repo
+      #   working-directory: certified-operators/operators/nginx-ingress-operator
+      #   run: |
+      #     mkdir v${{ needs.build.outputs.version }}
+      #     cp -R ../../../bundle/manifests v${{ needs.build.outputs.version }}/
+      #     cp -R ../../../bundle/metadata v${{ needs.build.outputs.version }}/
 
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
-        with:
-          commit_message: operator nginx-ingress-operator (v${{ needs.build.outputs.version }})
-          commit_author: nginx-bot <integrations@nginx.com>
-          commit_user_name: nginx-bot
-          commit_user_email: integrations@nginx.com
-          create_branch: true
-          branch: update-nginx-ingress-operator-to-v${{ needs.build.outputs.version }}
-          repository: certified-operators
+      # - name: Commit changes
+      #   uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+      #   with:
+      #     commit_message: operator nginx-ingress-operator (v${{ needs.build.outputs.version }})
+      #     commit_author: nginx-bot <integrations@nginx.com>
+      #     commit_user_name: nginx-bot
+      #     commit_user_email: integrations@nginx.com
+      #     create_branch: true
+      #     branch: update-nginx-ingress-operator-to-v${{ needs.build.outputs.version }}
+      #     repository: certified-operators
 
-      - name: Create PR
-        working-directory: certified-operators
-        run: |
-          gh pr create --title "operator nginx-ingress-operator (v${{ needs.build.outputs.version }})" --body "Update nginx-ingress-operator to v${{ needs.build.outputs.version }}" --head nginx-bot:update-nginx-ingress-operator-to-v${{ needs.build.outputs.version }} --base main --repo redhat-openshift-ecosystem/certified-operators
-        env:
-          GITHUB_TOKEN: ${{ secrets.NGINX_PAT }}
+      # - name: Create PR
+      #   working-directory: certified-operators
+      #   run: |
+      #     gh pr create --title "operator nginx-ingress-operator (v${{ needs.build.outputs.version }})" --body "Update nginx-ingress-operator to v${{ needs.build.outputs.version }}" --head nginx-bot:update-nginx-ingress-operator-to-v${{ needs.build.outputs.version }} --base main --repo redhat-openshift-ecosystem/certified-operators
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.NGINX_PAT }}

--- a/.github/workflows/sync-chart.yml
+++ b/.github/workflows/sync-chart.yml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout Operator
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          token: ${{ secrets.NGINX_PAT }}
 
       - name: Checkout Kubernetes json schemas
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,7 +64,6 @@ jobs:
           rm -f nginx-ingress/templates/controller-role.yaml
           rm -f nginx-ingress/templates/controller-rolebinding.yaml
           sed -i '14s/name: {{ include "nginx-ingress.fullname" . }}/name: nginx-ingress-operator-nginx-ingress-admin/' nginx-ingress/templates/clusterrolebinding.yaml
-          
           mv ../schemas/${{ inputs.k8s_version }} nginx-ingress/${{ inputs.k8s_version }}
           sed -i -e "s#ref\":.*_def#ref\": \"file://./helm-charts/nginx-ingress/${{ inputs.k8s_version }}/_def#" nginx-ingress/values.schema.json
           rm -rf ../schemas
@@ -108,11 +105,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ secrets.NGINX_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update NGINX Ingress Controller to ${{ steps.sync.outputs.new_nic_version }}
           title: Update NGINX Ingress Controller to ${{ steps.sync.outputs.new_nic_version }}
           branch: feat/update-nic-to-${{ steps.sync.outputs.new_nic_version }}
-          author: nginx-bot <integrations@nginx.com>
           body: |
             This automated PR updates the NGINX Ingress Controller to ${{ steps.sync.outputs.new_nic_version }}.
             The Helm Chart was updated to ${{ inputs.chart_version }}.


### PR DESCRIPTION
### Proposed changes

- `nginx-bot` is not required for sync-chart.yml workflow
- disable automated PR certification process, it will need to be done manually for now.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork