### PR TITLE
Fix Minikube in e2e tests to get latest supported Kubernetes version

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Get Latest Versions
         run: |
-          # Get latest Kubernetes version
-          echo "KUBERNETES_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | grep '"tag_name"' | cut -d'"' -f4)" >> $GITHUB_ENV
+          # Pin Kubernetes version to version supported by Minikube
+          echo "KUBERNETES_VERSION=v1.33.1" >> $GITHUB_ENV
           
           # Get latest Minikube version
           echo "MINIKUBE_VERSION=$(curl -s https://api.github.com/repos/kubernetes/minikube/releases/latest | grep '"tag_name"' | cut -d'"' -f4)" >> $GITHUB_ENV

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Get Latest Versions
         run: |
-          # Pin Kubernetes version to version supported by Minikube
-          echo "KUBERNETES_VERSION=v1.33.1" >> $GITHUB_ENV
+          # Get latest supported Kubernetes version from Minikube
+          echo "KUBERNETES_VERSION=v$(curl -s https://api.github.com/repos/kubernetes/minikube/releases/latest | jq -r '.body' | grep -o "Support Kubernetes version v[0-9]\+\.[0-9]\+\.[0-9]\+" | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+")" >> $GITHUB_ENV
           
           # Get latest Minikube version
           echo "MINIKUBE_VERSION=$(curl -s https://api.github.com/repos/kubernetes/minikube/releases/latest | grep '"tag_name"' | cut -d'"' -f4)" >> $GITHUB_ENV


### PR DESCRIPTION
### Proposed changes
Since Kubernetes v1.34.0 released, Minikube has been failing to start due to not supporting that version.

To fix the tests, it is best to check for latest supported Kubernetes version that minikube uses.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-ingress-operator/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork