### PR TITLE
Allow more permissions for headless service

### DIFF
--- a/bundle/manifests/nginx-ingress-operator-nginx-ingress-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/nginx-ingress-operator-nginx-ingress-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -40,6 +40,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -157,6 +157,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
### Proposed changes
Allow more permissions for headless service for zone-sync to work with operator.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-ingress-operator/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork